### PR TITLE
Add pump active/idle poll interval differentiation

### DIFF
--- a/rp_auto_default.ini
+++ b/rp_auto_default.ini
@@ -21,7 +21,8 @@ logfile: rp_auto_log.txt
 
 [runparams]
 quitfile: rp_auto_quit
-pollinterval: 1.0
+pollinterval: 10.0
+pollintwhilepumping: 1.0
 maxweight: 1.0
 minweight: 0.0
 dewarvolume: 100.0


### PR DESCRIPTION
Added an optional configuration parameter to set a different polling
time while the pump is active. If unset, it defaults to pollinterval